### PR TITLE
fix input file encoding

### DIFF
--- a/tutorial.py
+++ b/tutorial.py
@@ -46,7 +46,7 @@ if __name__ == '__main__':
     for line in open('train.dat'):
         label, file = line[:-1].split(',')
         dat = open(file, 'rb').read()
-        datum = Datum({"message": str(dat)})
+        datum = Datum({"message": dat.decode('latin1')})
         classifier.train([LabeledDatum(label, datum)])
 
     print(classifier.get_status())
@@ -62,7 +62,7 @@ if __name__ == '__main__':
     for line in open('test.dat'):
         label, file = line[:-1].split(',')
         dat = open(file, 'rb').read()
-        datum = Datum({"message": str(dat)})
+        datum = Datum({"message": dat.decode('latin1')})
         ans = classifier.classify([datum])
         if ans != None:
             estm = get_most_likely(ans[0])


### PR DESCRIPTION
News20 is encoded in Latin1, but this tutorial treats them as raw bytes.
As a result, Jubatus accepts invalid string that is not encoded in UTF-8.